### PR TITLE
feat: add sns topic for grafana alerts

### DIFF
--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/data_transfer_service.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/data_transfer_service.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "transfer_task_sg" {
 
 resource "aws_cloudwatch_log_group" "transfer_log_group" {
   name              = "/ecs/pillarbox-monitoring-transfer"
-  retention_in_days = 7 # Adjust the retention period as necessary
+  retention_in_days = 7
 
   tags = {
     Name = "data-transfer-log-group"

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/iam.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/iam.tf
@@ -130,6 +130,27 @@ resource "aws_iam_role_policy_attachment" "grafana_opensearch_policy_attach" {
   policy_arn = aws_iam_policy.grafana_opensearch_policy.arn
 }
 
+# SNS Publish Policy Document for Grafana
+data "aws_iam_policy_document" "grafana_sns_publish_policy" {
+  statement {
+    actions   = ["sns:Publish", "sns:GetTopicAttributes"]
+    resources = [aws_sns_topic.grafana_alerts.arn]
+  }
+}
+
+# SNS Publish Policy for Grafana
+resource "aws_iam_policy" "grafana_sns_publish_policy" {
+  name   = "grafana-sns-publish-policy"
+  policy = data.aws_iam_policy_document.grafana_sns_publish_policy.json
+}
+
+# Attach SNS Publish Policy to Grafana Role
+resource "aws_iam_role_policy_attachment" "grafana_sns_publish_policy_attach" {
+  role       = aws_iam_role.grafana_workspace_role.name
+  policy_arn = aws_iam_policy.grafana_sns_publish_policy.arn
+}
+
+
 # -----------------------------------
 # OpenSearch Access Policies
 # -----------------------------------

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/outputs.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/outputs.tf
@@ -12,3 +12,8 @@ output "dispatch_dns_name" {
   description = "The DNS name of the Dispatch Service Load Balancer"
   value       = aws_alb.dispatch_alb.dns_name
 }
+
+output "grafana_alert_topic" {
+  description = "The ARN of the topic for grafana alerts"
+  value       = aws_sns_topic.grafana_alerts.arn
+}

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/variables.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/variables.tf
@@ -24,5 +24,9 @@ variable "pillarbox_domain_name" {
   description = "The public domain name of the service"
   type        = string
   default     = "pillarbox.ch"
+}
 
+variable "alert_emails" {
+  description = "List of email addresses to subscribe to SNS topic for Grafana alerts"
+  type        = list(string)
 }


### PR DESCRIPTION
## Description

Resolves #8 by adding an SNS topic for grafana alerts.

## Changes Made

- Exposed SNS as a vpc endpoint.
- Created the SNS topic.
- Assigned necessary IAM roles to the Grafana workspace.
- Added an email subscription to the new topic, the email list can be configured through a variable.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
