### PR TITLE
Terraform backend

### DIFF
--- a/pillarbox-monitoring-terraform/10-pillarbox-monitoring-route-53/locals.tf
+++ b/pillarbox-monitoring-terraform/10-pillarbox-monitoring-route-53/locals.tf
@@ -5,5 +5,6 @@ locals {
     "srg-owner"         = "pillarbox-team@rts.ch"
     "srg-businessowner" = "pillarbox"
     "srg-environment"   = "prod"
+    "srg-repository"    = "SRGSSR/pillarbox-monitoring-infra"
   }
 }

--- a/pillarbox-monitoring-terraform/10-pillarbox-monitoring-route-53/main.tf
+++ b/pillarbox-monitoring-terraform/10-pillarbox-monitoring-route-53/main.tf
@@ -6,10 +6,10 @@ terraform {
   # Backend configuration for storing the Terraform state in S3 with DynamoDB table for state locking
   backend "s3" {
     encrypt        = true
-    bucket         = "pillarbox-monitoring-tfstate"
-    key            = "terraform/10-pillarbox-monitoring-route-53/terraform.tfstate"
-    dynamodb_table = "pillarbox-monitoring-terraform-statelock"
-    profile        = "prod"
+    bucket         = "rts-digital-terraform-backends-53a0d15f"
+    key            = "pillarbox-monitoring-infra/10-pillarbox-monitoring-route-53.tfstate"
+    dynamodb_table = "rts-digital-terraform-statelocks"
+    profile        = "services-prd"
   }
 
   # Specify required providers and their versions

--- a/pillarbox-monitoring-terraform/11-pillarbox-monitoring-ecr/locals.tf
+++ b/pillarbox-monitoring-terraform/11-pillarbox-monitoring-ecr/locals.tf
@@ -5,5 +5,6 @@ locals {
     "srg-owner"         = "pillarbox-team@rts.ch"
     "srg-businessowner" = "pillarbox"
     "srg-environment"   = "prod"
+    "srg-repository"    = "SRGSSR/pillarbox-monitoring-infra"
   }
 }

--- a/pillarbox-monitoring-terraform/11-pillarbox-monitoring-ecr/main.tf
+++ b/pillarbox-monitoring-terraform/11-pillarbox-monitoring-ecr/main.tf
@@ -6,10 +6,10 @@ terraform {
   # Backend configuration for storing the Terraform state in S3 with DynamoDB table for state locking
   backend "s3" {
     encrypt        = true
-    bucket         = "pillarbox-monitoring-tfstate"
-    key            = "terraform/11-pillarbox-monitoring-ecr/terraform.tfstate"
-    dynamodb_table = "pillarbox-monitoring-terraform-statelock"
-    profile        = "prod"
+    bucket         = "rts-digital-terraform-backends-53a0d15f"
+    key            = "pillarbox-monitoring-infra/11-pillarbox-monitoring-ecr.tfstate"
+    dynamodb_table = "rts-digital-terraform-statelocks"
+    profile        = "services-prd"
   }
 
   # Specify required providers and their versions

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
@@ -32,5 +32,6 @@ locals {
     "srg-owner"         = "pillarbox-team@rts.ch"
     "srg-businessowner" = "pillarbox"
     "srg-environment"   = terraform.workspace
+    "srg-repository"    = "SRGSSR/pillarbox-monitoring-infra"
   }
 }

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/main.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/main.tf
@@ -6,10 +6,10 @@ terraform {
   # Backend configuration for storing the Terraform state in S3 with DynamoDB table for state locking
   backend "s3" {
     encrypt        = true
-    bucket         = "pillarbox-monitoring-tfstate"
-    key            = "terraform/20-pillarbox-monitoring-app/terraform.tfstate"
-    dynamodb_table = "pillarbox-monitoring-terraform-statelock"
-    profile        = "prod"
+    bucket         = "rts-digital-terraform-backends-53a0d15f"
+    key            = "pillarbox-monitoring-infra/20-pillarbox-monitoring-app.tfstate"
+    dynamodb_table = "rts-digital-terraform-statelocks"
+    profile        = "services-prd"
   }
 
   # Specify required providers and their versions

--- a/pillarbox-monitoring-terraform/21-continuous-delivery/locals.tf
+++ b/pillarbox-monitoring-terraform/21-continuous-delivery/locals.tf
@@ -8,5 +8,6 @@ locals {
     "srg-owner"         = "pillarbox-team@rts.ch"
     "srg-businessowner" = "pillarbox"
     "srg-environment"   = terraform.workspace
+    "srg-repository"    = "SRGSSR/pillarbox-monitoring-infra"
   }
 }

--- a/pillarbox-monitoring-terraform/21-continuous-delivery/main.tf
+++ b/pillarbox-monitoring-terraform/21-continuous-delivery/main.tf
@@ -6,10 +6,10 @@ terraform {
   # Backend configuration for storing the Terraform state in S3 with DynamoDB table for state locking
   backend "s3" {
     encrypt        = true
-    bucket         = "pillarbox-monitoring-tfstate"
-    key            = "terraform/21-continuous-delivery/terraform.tfstate"
-    dynamodb_table = "pillarbox-monitoring-terraform-statelock"
-    profile        = "prod"
+    bucket         = "rts-digital-terraform-backends-53a0d15f"
+    key            = "pillarbox-monitoring-infra/21-continuous-delivery.tfstate"
+    dynamodb_table = "rts-digital-terraform-statelocks"
+    profile        = "services-prd"
   }
 
   # Specify required providers and their versions

--- a/pillarbox-monitoring-terraform/22-bastion/locals.tf
+++ b/pillarbox-monitoring-terraform/22-bastion/locals.tf
@@ -9,5 +9,6 @@ locals {
     "srg-owner"         = "pillarbox-team@rts.ch"
     "srg-businessowner" = "pillarbox"
     "srg-environment"   = terraform.workspace
+    "srg-repository"    = "SRGSSR/pillarbox-monitoring-infra"
   }
 }

--- a/pillarbox-monitoring-terraform/22-bastion/main.tf
+++ b/pillarbox-monitoring-terraform/22-bastion/main.tf
@@ -6,10 +6,10 @@ terraform {
   # Backend configuration for storing the Terraform state in S3 with DynamoDB table for state locking
   backend "s3" {
     encrypt        = true
-    bucket         = "pillarbox-monitoring-tfstate"
-    key            = "terraform/22-bastion/terraform.tfstate"
-    dynamodb_table = "pillarbox-monitoring-terraform-statelock"
-    profile        = "prod"
+    bucket         = "rts-digital-terraform-backends-53a0d15f"
+    key            = "pillarbox-monitoring-infra/22-bastion.tfstate"
+    dynamodb_table = "rts-digital-terraform-statelocks"
+    profile        = "services-prd"
   }
 
   # Specify required providers and their versions


### PR DESCRIPTION
## Description

We (RTS Digital) now have and use a single common Terraform backend (S3 bucket + DynamoDB table) for all our terraform deployments.  
We suggest to use this new backend for this repo as well.

## Changes Made

- Changed the Terraform backend configuration in all modules except 01-terraform-backend
- Added the "srg-repository" tag to AWS resources deployed by Terraform

## Actions needed

1. Add this profile to your `~/.aws/config`
```
[profile services-prd]
sso_start_url = https://srgssr.awsapps.com/start
sso_region = eu-central-1
sso_account_id = 404557912613
sso_role_name = Contributor
```
2. Perform a `terraform init -migrate-state` in each module except `01-terraform-backend`
3. Perform a `terraform plan` in each module to check everything is alright
4. Perform a `terraform destroy` in `01-terraform-backend` module if its resources are actually unused
5. Create a new PR to delete the `01-terraform-backend` module files and update the project README accordingly

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
