### PR TITLE
chore: add more storage to opensearch ebs

### DIFF
--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
@@ -8,10 +8,10 @@ locals {
 
   opensearch = {
     domain_name   = "${var.application_name}-search"
-    volume_size   = local.is_prod ? 100 : 10
+    volume_size   = local.is_prod ? 300 : 10
     instance_type = local.is_prod ? "m7g.medium.search" : "t3.small.search"
     volume_type   = local.is_prod ? "gp3" : "gp2"
-    throughput    = local.is_prod ? 125 : null
+    throughput    = local.is_prod ? 250 : null
   }
 
   domain_name = local.is_prod ? "monitoring.pillarbox.ch" : "dev.monitoring.pillarbox.ch"


### PR DESCRIPTION
## Description

Expanded the EBS storage to retain more data for the monitoring.

## Changes Made

Adds 200Gb of storage to each node of the OpenSearch cluster.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
