### PR TITLE
fix: reduce vpc endpoints to lower costs

### DIFF
--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/main.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/main.tf
@@ -142,7 +142,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   vpc_id              = data.aws_vpc.main_vpc.id
   service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = data.aws_subnets.private_subnets.ids
+  subnet_ids          = [data.aws_subnets.private_subnets.ids[0]]
   security_group_ids  = [aws_security_group.vpc_endpoints_sg.id]
   private_dns_enabled = true
 
@@ -156,25 +156,12 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_id              = data.aws_vpc.main_vpc.id
   service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = data.aws_subnets.private_subnets.ids
+  subnet_ids          = [data.aws_subnets.private_subnets.ids[0]]
   security_group_ids  = [aws_security_group.vpc_endpoints_sg.id]
   private_dns_enabled = true
 
   tags = {
     Name = "vpc-ecr-dkr-endpoint"
-  }
-}
-
-# VPC Endpoint for S3
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = data.aws_vpc.main_vpc.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
-  vpc_endpoint_type = "Gateway"
-
-  route_table_ids = data.aws_route_tables.private_route_tables.ids
-
-  tags = {
-    Name = "vpc-s3-endpoint"
   }
 }
 


### PR DESCRIPTION
## Description

Removed unused and redundant VPC endpoints to cut monitoring system expenses:

## Changes Made

- S3: No longer needed.
- ECR API & ECR DKR: Limited to a single availability zone where ECS runs.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
