### PR TITLE
feat: add integration layer proxy

### DIFF
--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/grafana.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/grafana.tf
@@ -7,13 +7,13 @@ resource "aws_security_group" "grafana_sg" {
   name   = "grafana-sg"
   vpc_id = data.aws_vpc.main_vpc.id
 
-  # Ingress rule: Allow inbound traffic from OpenSearch on port 443
+  # Ingress rule: Allow all inbound traffic
   ingress {
-    description = "Allow all inbound traffic from OpenSearch"
+    description = "Allow all inbound traffic"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # Adjust CIDR block to restrict access
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   # Egress rule: Allow all outbound traffic
@@ -31,7 +31,6 @@ resource "aws_security_group" "grafana_sg" {
 }
 
 ## Create a Grafana Workspace for monitoring with OpenSearch as the data source
-
 resource "aws_grafana_workspace" "grafana_workspace" {
   name                      = "${var.application_name}-grafana"
   account_access_type       = "CURRENT_ACCOUNT"                       # Restrict Grafana workspace to the current AWS account

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/il_proxy.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/il_proxy.tf
@@ -1,0 +1,68 @@
+# -----------------------------------
+# IL Proxy Setup
+# -----------------------------------
+
+# EC2 Instance for the IL proxy
+resource "aws_instance" "il_proxy" {
+  ami                         = local.il_proxy.ami
+  instance_type               = local.il_proxy.instance_type
+  subnet_id                   = data.aws_subnets.public_subnets.ids[0] # Use a private subnet
+  vpc_security_group_ids      = [aws_security_group.il_proxy_sg.id]
+  associate_public_ip_address = true
+
+  # Nginx setup
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo yum update -y
+              sudo yum install -y nginx
+
+              sudo cat <<EOT > /etc/nginx/default.d/reverse-proxy.conf
+              location / {
+                  if (\$http_x_api_key != "${local.il_proxy.api_key}") {
+                      return 403;
+                  }
+
+                  proxy_pass https://il.srgssr.ch; # Proxy to the external API
+                  proxy_set_header Host il.srgssr.ch;
+                  proxy_set_header X-Real-IP \$remote_addr;
+                  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+                  proxy_set_header X-Forwarded-Proto \$scheme;
+              }
+              EOT
+
+              sudo systemctl start nginx
+              sudo systemctl enable nginx
+              EOF
+
+  tags = {
+    Name = "il-proxy-instance"
+  }
+}
+
+# Security Group for the IL proxy
+resource "aws_security_group" "il_proxy_sg" {
+  name   = "il-proxy-sg"
+  vpc_id = data.aws_vpc.main_vpc.id
+
+  # Ingress rule: Allow inbound traffic from VPC
+  ingress {
+    description = "Allow inbound traffic from the VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Egress rule: Allow all outbound traffic
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "il-proxy-sg"
+  }
+}

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
@@ -14,6 +14,12 @@ locals {
     throughput    = local.is_prod ? 250 : null
   }
 
+  il_proxy = {
+    ami           = "ami-0d7c381edfc5ee30e"
+    instance_type = "t4g.nano"
+    api_key       = var.il_proxy_api_key[terraform.workspace]
+  }
+
   domain_name = local.is_prod ? "monitoring.pillarbox.ch" : "dev.monitoring.pillarbox.ch"
 
   transfer_task = {

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/outputs.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/outputs.tf
@@ -17,3 +17,8 @@ output "grafana_alert_topic" {
   description = "The ARN of the topic for grafana alerts"
   value       = aws_sns_topic.grafana_alerts.arn
 }
+
+output "ec2_proxy_private_ip" {
+  description = "Private IP of the EC2 Nginx Proxy Instance (accessible within VPC)"
+  value       = aws_instance.il_proxy.private_ip
+}

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/sse_broker_service.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/sse_broker_service.tf
@@ -251,7 +251,7 @@ resource "aws_security_group" "dispatch_task_sg" {
 
 resource "aws_cloudwatch_log_group" "dispatch_log_group" {
   name              = "/ecs/pillarbox-event-dispatcher"
-  retention_in_days = 7 # Adjust the retention as needed
+  retention_in_days = 7
 
   tags = {
     Name = "dispatch-log-group"

--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/variables.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/variables.tf
@@ -30,3 +30,8 @@ variable "alert_emails" {
   description = "List of email addresses to subscribe to SNS topic for Grafana alerts"
   type        = list(string)
 }
+
+variable "il_proxy_api_key" {
+  description = "The API key to the IL proxy by terraform workspace"
+  type        = map(string)
+}


### PR DESCRIPTION
## Description

Resolves #20 by creating an EC2 instance with a reverse proxy to the IL. This will allow to prefetch metadata on Grafana to monitor specific livestreams. 

## Changes Made

- Added a new EC2 host with an nginx that serves as an API gateway to the IL from within the VPC.
- The proxy is protected with an API token.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
