### PR TITLE
fix: restore s3 endpoint

### DIFF
--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/main.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/main.tf
@@ -142,7 +142,7 @@ resource "aws_vpc_endpoint" "ecr_api" {
   vpc_id              = data.aws_vpc.main_vpc.id
   service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.api"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [data.aws_subnets.private_subnets.ids[0]]
+  subnet_ids          = data.aws_subnets.private_subnets.ids
   security_group_ids  = [aws_security_group.vpc_endpoints_sg.id]
   private_dns_enabled = true
 
@@ -156,7 +156,7 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_id              = data.aws_vpc.main_vpc.id
   service_name        = "com.amazonaws.${data.aws_region.current.name}.ecr.dkr"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = [data.aws_subnets.private_subnets.ids[0]]
+  subnet_ids          = data.aws_subnets.private_subnets.ids
   security_group_ids  = [aws_security_group.vpc_endpoints_sg.id]
   private_dns_enabled = true
 
@@ -179,6 +179,18 @@ resource "aws_vpc_endpoint" "cloudwatch_logs" {
   }
 }
 
+# VPC Endpoint for S3
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = data.aws_vpc.main_vpc.id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+
+  route_table_ids = data.aws_route_tables.private_route_tables.ids
+
+  tags = {
+    Name = "vpc-s3-endpoint"
+  }
+}
 
 # Security Group for the SNS VPC Endpoint
 resource "aws_security_group" "sns_vpc_endpoint_sg" {


### PR DESCRIPTION
## Description

Restore the S3 VPC endpoint. This endpoint is needed to retrieve images from the ECR.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
