### PR TITLE
chore: add dashboard backup workflow

### DIFF
--- a/.github/workflows/dashboard-backup.yml
+++ b/.github/workflows/dashboard-backup.yml
@@ -1,0 +1,48 @@
+name: Grafana Dashboard Backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Grafana Sync
+        uses: srgssr/grafana-sync-action@v1.2.0
+        with:
+          grafana-url: ${{ secrets.GRAFANA_URL }}
+          api-key: ${{ secrets.GRAFANA_API_KEY }}
+          dir: 'pillarbox-monitoring-grafana/dashboards'
+          clear: true
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: pillarbox-monitoring-grafana/dashboards
+          commit-message: "chore: automated grafana dashboard backup"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>"
+          signoff: false
+          draft: false
+          delete-branch: true
+          branch: "chore/update-grafana-dashboards"
+          title: "chore: automated backup of grafana dashboards"
+          body: |
+            ## Description
+
+            This pull request contains the latest backup of our Grafana dashboards, automatically synchronized from our
+            live environment. These updates ensure that the repository accurately reflects the current dashboard
+            configurations used for monitoring.

--- a/pillarbox-monitoring-grafana/Dockerfile
+++ b/pillarbox-monitoring-grafana/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for grafana
-FROM grafana/grafana:10.4.1
+FROM grafana/grafana:11.5.2
 
 # Copy provisioning and dashboards
 COPY ./provisioning /etc/grafana/provisioning
@@ -9,5 +9,5 @@ COPY ./dashboards /var/lib/grafana/dashboards
 ENV GF_AUTH_ANONYMOUS_ENABLED=true \
     GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \
     GF_AUTH_DISABLE_LOGIN_FORM=true \
-    GF_INSTALL_PLUGINS=grafana-opensearch-datasource
+    GF_INSTALL_PLUGINS=grafana-opensearch-datasource,yesoreyeram-infinity-datasource
 

--- a/pillarbox-monitoring-grafana/provisioning/dashboards/dashboard.yml
+++ b/pillarbox-monitoring-grafana/provisioning/dashboards/dashboard.yml
@@ -6,7 +6,8 @@ providers:
     folder: ''
     type: file
     disableDeletion: false
+    editable: true
     updateIntervalSeconds: 10
     options:
-      path: /var/lib/grafana/dashboards
+      path: /var/lib/grafana/dashboards/Player
 

--- a/pillarbox-monitoring-grafana/provisioning/datasources/datasource.yml
+++ b/pillarbox-monitoring-grafana/provisioning/datasources/datasource.yml
@@ -1,6 +1,6 @@
 apiVersion: 1
 datasources:
-  - name: opensearch
+  - name: user-events
     type: grafana-opensearch-datasource
     typeName: OpenSearch
     typeLogoUrl: public/img/icn-datasource.svg
@@ -20,5 +20,14 @@ datasources:
       timeField: "@timestamp"
       version: 2.17.0
       versionLabel: OpenSearch 2.17.0
+    readOnly: false
 
+  - name: integration-layer
+    type: yesoreyeram-infinity-datasource
+    typeName: Infinity
+    typeLogoUrl: public/img/icn-datasource.svg
+    access: proxy
+    jsonData:
+      dataSourceType: JSON
+      baseURL: https://il.srgssr.ch
     readOnly: false


### PR DESCRIPTION
## Description

Resolves #29 by integrating srgssr/grafana-sync-action to periodically backup Grafana dashboards using a scheduled workflow.

## Changes

- Added new backup action workflow.
- Provisioned infinity plugin for rest API data sources.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
