### PR TITLE
chore: adapted grafana provisioning and updated backup workflow

### DIFF
--- a/.github/workflows/dashboard-backup.yml
+++ b/.github/workflows/dashboard-backup.yml
@@ -36,7 +36,7 @@ jobs:
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           author: "${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>"
           signoff: false
-          draft: false
+          draft: always-true
           delete-branch: true
           branch: "chore/update-grafana-dashboards"
           title: "chore: automated backup of grafana dashboards"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,11 @@ on:
   merge_group:
   pull_request:
     branches: [ main ]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   terraform-format-check:

--- a/pillarbox-monitoring-grafana/provisioning/datasources/datasource.yml
+++ b/pillarbox-monitoring-grafana/provisioning/datasources/datasource.yml
@@ -1,6 +1,7 @@
 apiVersion: 1
 datasources:
   - name: user-events
+    uid: fef4oi750u39cd
     type: grafana-opensearch-datasource
     typeName: OpenSearch
     typeLogoUrl: public/img/icn-datasource.svg
@@ -20,14 +21,13 @@ datasources:
       timeField: "@timestamp"
       version: 2.17.0
       versionLabel: OpenSearch 2.17.0
-    readOnly: false
+    editable: true
 
   - name: integration-layer
+    uid: cef4oofzuaayof
     type: yesoreyeram-infinity-datasource
     typeName: Infinity
     typeLogoUrl: public/img/icn-datasource.svg
     access: proxy
-    jsonData:
-      dataSourceType: JSON
-      baseURL: https://il.srgssr.ch
-    readOnly: false
+    url: https://il.srgssr.ch
+    editable: true


### PR DESCRIPTION
## Description

Adapts the local Grafana provisioning to match the backed-up dashboards.
This change allows for smoother testing when running the full stack with Docker Compose.

## Changes Made

- Added UID to all datasource provisioning to match the remote UID.
- Fixed URL provisioning for the Integration Layer datasource.
- Made provisioned datasources editable.
- Configure create-pull-request to always open drafts for the backup workflow
- Added a `reaady_for_review` trigger on the quality action.
- Updated the dashboard export guide.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
