### PR TITLE
fix: right size optimizations

### DIFF
--- a/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
+++ b/pillarbox-monitoring-terraform/20-pillarbox-monitoring-app/locals.tf
@@ -12,10 +12,10 @@ locals {
     domain_name   = "${var.application_name}-search"
     instance_type = local.is_prod ? "r7g.xlarge" : "t4g.medium"
     volume = {
-      type       = local.is_prod ? "gp3" : "gp2"
+      type       = "gp3"
       size       = local.is_prod ? 500 : 20,
-      iops       = local.is_prod ? 6000 : null
-      throughput = local.is_prod ? 300 : null
+      iops       = 3000
+      throughput = 125
     }
     java_opts = local.is_prod ? "-Xms16g -Xmx16g" : "-Xms2g -Xmx2g"
   }
@@ -28,7 +28,7 @@ locals {
 
   transfer = {
     task = {
-      cpu       = local.is_prod ? 2048 : 512
+      cpu       = local.is_prod ? 2048 : 256
       memory    = local.is_prod ? 16384 : 1024
       java_opts = local.is_prod ? "-Xms14G -Xmx14G" : "-Xms1G -Xmx1G"
     }


### PR DESCRIPTION
## Description

Resized the infrastructure to optimise the cost following AWS recomendations.

## Changes Made

On the dev environment the following optimisations have been applied:

- The `data-transfer` service cpu provisioning has been reduced from .512 to .256
- The opensearch disk type is now `gp3` instead of `gp2`

On the prod environmen the following optimisations have been applied:

- The opensearch disk throughtpu is now `125` instead of `300`
- The same disk iops has been reduced to `3000` from `6000`

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
