### PR TITLE
feat: add pillarbox-demo-backend ecr and authorize github actions access

### DIFF
--- a/pillarbox-monitoring-terraform/11-pillarbox-monitoring-ecr/variables.tf
+++ b/pillarbox-monitoring-terraform/11-pillarbox-monitoring-ecr/variables.tf
@@ -4,6 +4,7 @@ variable "ecr_repositories" {
   default = {
     "pillarbox-event-dispatcher"    = "SRGSSR/pillarbox-event-dispatcher"
     "pillarbox-monitoring-transfer" = "SRGSSR/pillarbox-monitoring-transfer"
+    "pillarbox-demo-backend"        = "SRGSSR/pillarbox-demo-backend"
   }
 }
 

--- a/pillarbox-monitoring-terraform/21-continuous-delivery/locals.tf
+++ b/pillarbox-monitoring-terraform/21-continuous-delivery/locals.tf
@@ -2,6 +2,13 @@ locals {
   ecs_cluster_name = "${var.application_name}-cluster"
   is_prod          = terraform.workspace == "prod"
 
+  services_with_policy = tomap(
+    {
+      for name, service_config in var.service_mappings :
+      name => service_config if(local.is_prod || service_config.ecs)
+    }
+  )
+
   default_tags = {
     "srg-managed-by"    = "terraform"
     "srg-application"   = var.application_name

--- a/pillarbox-monitoring-terraform/21-continuous-delivery/outputs.tf
+++ b/pillarbox-monitoring-terraform/21-continuous-delivery/outputs.tf
@@ -1,0 +1,7 @@
+output "gha_role_arns" {
+  description = "ARNs of the GitHub Actions IAM roles"
+  value = {
+    for name, role in aws_iam_role.gha_role :
+    name => role.arn
+  }
+}

--- a/pillarbox-monitoring-terraform/21-continuous-delivery/variables.tf
+++ b/pillarbox-monitoring-terraform/21-continuous-delivery/variables.tf
@@ -19,16 +19,24 @@ variable "service_mappings" {
   type = map(object({
     github_repo_name = string
     ecr_image_name   = string
+    ecs              = bool
   }))
 
   default = {
     "dispatch-service" = {
       github_repo_name = "SRGSSR/pillarbox-event-dispatcher"
       ecr_image_name   = "pillarbox-event-dispatcher"
+      ecs              = true
     }
     "data-transfer-service" = {
       github_repo_name = "SRGSSR/pillarbox-monitoring-transfer"
       ecr_image_name   = "pillarbox-monitoring-transfer"
+      ecs              = true
+    }
+    "pillarbox-demo-backend" = {
+      github_repo_name = "SRGSSR/pillarbox-demo-backend"
+      ecr_image_name   = "pillarbox-demo-backend"
+      ecs              = false
     }
   }
 }


### PR DESCRIPTION
## Description

Create a new ECR repository for the `pillarbox-demo-backend`.

## Changes Made

- Adds new roles and policies allowing github to publish images on the new ECR from the `srgssr/pillarbox-demo-backend` repository.
- Removed depreacted `inline_policy` from the `aws_iam_role` resource in favor of a `aws_iam_role_policy` resource link to the policy document.


## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
